### PR TITLE
feat: 이메일 인증코드 전송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
     //fcm
     implementation 'com.google.firebase:firebase-admin:9.1.1'
+
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {
@@ -144,7 +147,8 @@ tasks.processResources {
                 DB_USERNAME: System.getenv('DB_USERNAME'),
                 DB_PASSWORD: System.getenv('DB_PASSWORD'),
                 JWT_SECRET_KEY: System.getenv('JWT_SECRET_KEY'),
-                AES_KEY: System.getenv('AES_KEY')
+                AES_KEY: System.getenv('AES_KEY'),
+                EMAIL_PASSWORD: System.getenv('EMAIL_PASSWORD')
         )
     }
 }

--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -111,3 +111,16 @@ include::{snippets}/user-update-info/request-fields.adoc[]
 
 include::{snippets}/user-update-info/http-response.adoc[]
 include::{snippets}/user-update-info/response-fields.adoc[]
+
+[[send-mail]]
+=== 이메일 인증코드 전송
+
+==== HTTP Request
+
+include::{snippets}/send-mail/http-request.adoc[]
+include::{snippets}/send-mail/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/send-mail/http-response.adoc[]
+include::{snippets}/send-mail/response-fields.adoc[]

--- a/src/main/java/com/addiction/user/users/controller/LoginController.java
+++ b/src/main/java/com/addiction/user/users/controller/LoginController.java
@@ -1,48 +1,49 @@
 package com.addiction.user.users.controller;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.addiction.global.ApiResponse;
 import com.addiction.user.users.controller.request.LoginOauthRequest;
 import com.addiction.user.users.controller.request.LoginRequest;
+import com.addiction.user.users.controller.request.SendAuthCodeRequest;
 import com.addiction.user.users.controller.request.UserSaveRequest;
+import com.addiction.user.users.service.LoginService;
 import com.addiction.user.users.service.UserService;
 import com.addiction.user.users.service.response.LoginResponse;
 import com.addiction.user.users.service.response.OAuthLoginResponse;
-import com.addiction.user.users.service.LoginService;
+import com.addiction.user.users.service.response.SendAuthCodeResponse;
 import com.addiction.user.users.service.response.UserSaveResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class LoginController {
 
-	private final LoginService loginService;
-	private final UserService userService;
+    private final LoginService loginService;
+    private final UserService userService;
 
-	@PostMapping("/login")
-	public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) throws JsonProcessingException {
-		return ApiResponse.ok(loginService.normalLogin(loginRequest.toServiceRequest()));
-	}
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) throws JsonProcessingException {
+        return ApiResponse.ok(loginService.normalLogin(loginRequest.toServiceRequest()));
+    }
 
-	@PostMapping("/oauth/login")
-	public ApiResponse<OAuthLoginResponse> oauthLogin(@Valid @RequestBody LoginOauthRequest loginOauthRequest) throws JsonProcessingException {
-		return ApiResponse.ok(loginService.oauthLogin(loginOauthRequest.toServiceRequest()));
-	}
+    @PostMapping("/oauth/login")
+    public ApiResponse<OAuthLoginResponse> oauthLogin(@Valid @RequestBody LoginOauthRequest loginOauthRequest) throws JsonProcessingException {
+        return ApiResponse.ok(loginService.oauthLogin(loginOauthRequest.toServiceRequest()));
+    }
 
-	@PostMapping("/join")
-	@ResponseStatus(HttpStatus.CREATED)
-	public ApiResponse<UserSaveResponse> save(@RequestBody @Valid UserSaveRequest userSaveRequest) {
-		return ApiResponse.created(userService.save(userSaveRequest.toServiceRequest()));
-	}
+    @PostMapping("/join")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<UserSaveResponse> save(@RequestBody @Valid UserSaveRequest userSaveRequest) {
+        return ApiResponse.created(userService.save(userSaveRequest.toServiceRequest()));
+    }
+
+    @PostMapping("/mail")
+    public ApiResponse<SendAuthCodeResponse> sendMail(@Valid @RequestBody SendAuthCodeRequest sendAuthCodeRequest) {
+        return ApiResponse.ok(loginService.sendMail(sendAuthCodeRequest.toServiceRequest()));
+    }
 
 }

--- a/src/main/java/com/addiction/user/users/controller/request/SendAuthCodeRequest.java
+++ b/src/main/java/com/addiction/user/users/controller/request/SendAuthCodeRequest.java
@@ -1,0 +1,26 @@
+package com.addiction.user.users.controller.request;
+
+import com.addiction.user.users.service.request.SendAuthCodeServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SendAuthCodeRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+
+    public SendAuthCodeServiceRequest toServiceRequest(){
+        return SendAuthCodeServiceRequest.builder()
+                .email(email)
+                .build();
+    }
+
+    @Builder
+    public SendAuthCodeRequest(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/addiction/user/users/controller/request/SendAuthCodeRequest.java
+++ b/src/main/java/com/addiction/user/users/controller/request/SendAuthCodeRequest.java
@@ -1,6 +1,7 @@
 package com.addiction.user.users.controller.request;
 
 import com.addiction.user.users.service.request.SendAuthCodeServiceRequest;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class SendAuthCodeRequest {
 
     @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 
     public SendAuthCodeServiceRequest toServiceRequest(){

--- a/src/main/java/com/addiction/user/users/service/LoginService.java
+++ b/src/main/java/com/addiction/user/users/service/LoginService.java
@@ -2,8 +2,10 @@ package com.addiction.user.users.service;
 
 import com.addiction.user.users.service.request.LoginServiceRequest;
 import com.addiction.user.users.service.request.OAuthLoginServiceRequest;
+import com.addiction.user.users.service.request.SendAuthCodeServiceRequest;
 import com.addiction.user.users.service.response.LoginResponse;
 import com.addiction.user.users.service.response.OAuthLoginResponse;
+import com.addiction.user.users.service.response.SendAuthCodeResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface LoginService {
@@ -13,5 +15,5 @@ public interface LoginService {
 	OAuthLoginResponse oauthLogin(OAuthLoginServiceRequest oAuthLoginServiceRequest) throws
 		JsonProcessingException;
 
-
+    SendAuthCodeResponse sendMail(SendAuthCodeServiceRequest sendAuthCodeServiceRequest);
 }

--- a/src/main/java/com/addiction/user/users/service/impl/LoginServiceImpl.java
+++ b/src/main/java/com/addiction/user/users/service/impl/LoginServiceImpl.java
@@ -130,7 +130,7 @@ public class LoginServiceImpl implements LoginService {
         return SendAuthCodeResponse.createResponse(authKey);
     }
 
-    public void sendMail(SendMailRequest sendMailRequest) {
+    private void sendMail(SendMailRequest sendMailRequest) {
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         try {
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");

--- a/src/main/java/com/addiction/user/users/service/request/SendAuthCodeServiceRequest.java
+++ b/src/main/java/com/addiction/user/users/service/request/SendAuthCodeServiceRequest.java
@@ -1,0 +1,15 @@
+package com.addiction.user.users.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SendAuthCodeServiceRequest {
+
+    private final String email;
+
+    @Builder
+    private SendAuthCodeServiceRequest(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/addiction/user/users/service/request/SendMailRequest.java
+++ b/src/main/java/com/addiction/user/users/service/request/SendMailRequest.java
@@ -1,0 +1,19 @@
+package com.addiction.user.users.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class SendMailRequest {
+    private final String email;
+    private final String subject;
+    private final String text;
+
+    @Builder
+    private SendMailRequest(String email, String subject, String text) {
+        this.email = email;
+        this.subject = subject;
+        this.text = text;
+    }
+}

--- a/src/main/java/com/addiction/user/users/service/response/SendAuthCodeResponse.java
+++ b/src/main/java/com/addiction/user/users/service/response/SendAuthCodeResponse.java
@@ -1,0 +1,22 @@
+package com.addiction.user.users.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SendAuthCodeResponse {
+
+    private final String authCode;
+
+    @Builder
+    private SendAuthCodeResponse(String authCode) {
+        this.authCode = authCode;
+    }
+
+    public static SendAuthCodeResponse createResponse(String authCode){
+        return SendAuthCodeResponse.builder()
+            .authCode(authCode)
+            .build();
+    }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -46,6 +46,18 @@ spring:
           p6spy:
             enable-logging: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: addiction1215@gmail.com
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+          auth: true
+
 oauth:
   kakao:
     api:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -14,6 +14,17 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         jdbc:
           exception-handling: ignore
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: addiction1215@gmail.com
+    password: test
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+          auth: true
 
 oauth:
   kakao:

--- a/src/test/java/com/addiction/user/users/controller/LoginControllerTest.java
+++ b/src/test/java/com/addiction/user/users/controller/LoginControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.addiction.user.users.controller.request.SendAuthCodeRequest;
 import com.addiction.user.users.entity.enums.Sex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -376,5 +377,50 @@ public class LoginControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.statusCode").value("400"))
                 .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
                 .andExpect(jsonPath("$.message").value("성별은 필수입니다."));
+    }
+
+    @DisplayName("이메일 전송 테스트")
+    @Test
+    @WithMockUser(roles = "USER")
+    void 이메일_전송_테스트() throws Exception {
+        // given
+        SendAuthCodeRequest request = SendAuthCodeRequest.builder()
+                .email("tkdrl8908@naver.com")
+                .build();
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/v1/auth/mail")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("200"))
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @DisplayName("이메일은 필수이다.")
+    @Test
+    @WithMockUser(roles = "USER")
+    void 이메일_전송_테스트시에는_이메일은_필수이다() throws Exception {
+        // given
+        SendAuthCodeRequest request = SendAuthCodeRequest.builder()
+                .build();
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/v1/auth/mail")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value("400"))
+                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("이메일은 필수입니다."));
     }
 }

--- a/src/test/java/com/addiction/user/users/controller/LoginControllerTest.java
+++ b/src/test/java/com/addiction/user/users/controller/LoginControllerTest.java
@@ -423,4 +423,50 @@ public class LoginControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
                 .andExpect(jsonPath("$.message").value("이메일은 필수입니다."));
     }
+
+    @DisplayName("이메일 형식이 올바르지 않으면 오류가 발생한다.")
+    @Test
+    @WithMockUser(roles = "USER")
+    void 이메일_형식이_올바르지_않으면_오류가_발생한다() throws Exception {
+        // given
+        SendAuthCodeRequest request = SendAuthCodeRequest.builder()
+                .email("invalid-email")
+                .build();
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/v1/auth/mail")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value("400"))
+                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("올바른 이메일 형식이 아닙니다."));
+    }
+
+    @DisplayName("이메일에 @가 없으면 오류가 발생한다.")
+    @Test
+    @WithMockUser(roles = "USER")
+    void 이메일에_골뱅이가_없으면_오류가_발생한다() throws Exception {
+        // given
+        SendAuthCodeRequest request = SendAuthCodeRequest.builder()
+                .email("testtest.com")
+                .build();
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/v1/auth/mail")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value("400"))
+                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("올바른 이메일 형식이 아닙니다."));
+    }
 }

--- a/src/test/java/com/addiction/user/users/service/LoginServiceTest.java
+++ b/src/test/java/com/addiction/user/users/service/LoginServiceTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
+import com.addiction.user.users.service.request.SendAuthCodeServiceRequest;
+import com.addiction.user.users.service.response.SendAuthCodeResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
회원가입 시 사용하는 이메일 인증코드 전송 API 입니다.

6자리 숫자를 랜덤하게 생성하고 있고 프론트에 응답값으로 내려주고 있습니다.

프론트에 현재 평문으로 내려주고 있는데 보안떔에 프론트와 키를 정하여 AES 양방향 암호화를 할까하는데

각 재직중인 회사에서 비슷한 사례가 있을까요?