### PR TITLE
feat: 마지막 흡연 기록 조회 api

### DIFF
--- a/src/docs/asciidoc/api/userCigaretteHistory/userCigaretteHistory.adoc
+++ b/src/docs/asciidoc/api/userCigaretteHistory/userCigaretteHistory.adoc
@@ -36,3 +36,16 @@ include::{snippets}/user-cigarette-history-graph/query-parameters.adoc[]
 
 include::{snippets}/user-cigarette-history-graph/http-response.adoc[]
 include::{snippets}/user-cigarette-history-graph/response-fields.adoc[]
+
+[[user-cigarette-history-latest]]
+=== 회원 마지막 흡연 기록 조회 API
+
+==== HTTP Request
+
+include::{snippets}/user-cigarette-history-latest/http-request.adoc[]
+include::{snippets}/user-cigarette-history-latest/query-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/user-cigarette-history-latest/http-response.adoc[]
+include::{snippets}/user-cigarette-history-latest/response-fields.adoc[]

--- a/src/main/java/com/addiction/user/userCigarette/repository/UserCigaretteJpaRepository.java
+++ b/src/main/java/com/addiction/user/userCigarette/repository/UserCigaretteJpaRepository.java
@@ -24,4 +24,5 @@ public interface UserCigaretteJpaRepository extends JpaRepository<UserCigarette,
 	List<UserCigarette> findAllByCreatedDateBetween(LocalDateTime start, LocalDateTime end);
 
 	Optional<UserCigarette> findTopByUserIdOrderByCreatedDateDesc(Long userId);
+
 }

--- a/src/main/java/com/addiction/user/userCigarette/service/impl/UserCigaretteServiceImpl.java
+++ b/src/main/java/com/addiction/user/userCigarette/service/impl/UserCigaretteServiceImpl.java
@@ -16,6 +16,8 @@ import com.addiction.user.users.service.UserReadService;
 
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -38,7 +40,7 @@ public class UserCigaretteServiceImpl implements UserCigaretteService {
 
 			if (lastCigarette != null) {
 				intervalMinutes = java.time.Duration.between(
-					lastCigarette.getCreatedDate(), java.time.LocalDateTime.now()
+					lastCigarette.getCreatedDate(), LocalDateTime.now()
 				).toMinutes();
 			}
 			UserCigarette userCigarette = UserCigarette.createEntity(

--- a/src/main/java/com/addiction/user/userCigaretteHistory/controller/UserCigaretteHistoryController.java
+++ b/src/main/java/com/addiction/user/userCigaretteHistory/controller/UserCigaretteHistoryController.java
@@ -2,6 +2,7 @@ package com.addiction.user.userCigaretteHistory.controller;
 
 import java.util.List;
 
+import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryLastestResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,5 +37,10 @@ public class UserCigaretteHistoryController {
 	public ApiResponse<UserCigaretteHistoryGraphResponse> findGraphByPeriod(PeriodType periodType) {
 		return ApiResponse.ok(userCigaretteHistoryService.findGraphByPeriod(periodType));
 	}
+
+    @GetMapping("/lastest")
+    public ApiResponse<UserCigaretteHistoryLastestResponse> findLastestByUserId() {
+        return ApiResponse.ok(userCigaretteHistoryService.findLastestByUserId());
+    }
 
 }

--- a/src/main/java/com/addiction/user/userCigaretteHistory/repository/UserCigaretteHistoryRepository.java
+++ b/src/main/java/com/addiction/user/userCigaretteHistory/repository/UserCigaretteHistoryRepository.java
@@ -12,4 +12,6 @@ public interface UserCigaretteHistoryRepository {
 	CigaretteHistoryDocument findByDateAndUserId(String date, Long userId);
 
 	List<CigaretteHistoryDocument> findByUserIdAndDateBetween(Long userId, String startDate, String endDate);
+
+    CigaretteHistoryDocument findLatestByUserId(Long userId);
 }

--- a/src/main/java/com/addiction/user/userCigaretteHistory/repository/impl/UserCigaretteHistoryRepositoryImpl.java
+++ b/src/main/java/com/addiction/user/userCigaretteHistory/repository/impl/UserCigaretteHistoryRepositoryImpl.java
@@ -5,6 +5,7 @@ import static org.springframework.data.mongodb.core.query.Query.*;
 
 import java.util.List;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -56,4 +57,13 @@ public class UserCigaretteHistoryRepositoryImpl implements UserCigaretteHistoryR
 			CigaretteHistoryDocument.class
 		);
 	}
+
+    @Override
+    public CigaretteHistoryDocument findLatestByUserId(Long userId) {
+        return mongoTemplate.findOne(
+                query(where("userId").is(userId))
+                        .with(Sort.by(Sort.Direction.DESC, "date")),
+                CigaretteHistoryDocument.class
+        );
+    }
 }

--- a/src/main/java/com/addiction/user/userCigaretteHistory/service/UserCigaretteHistoryService.java
+++ b/src/main/java/com/addiction/user/userCigaretteHistory/service/UserCigaretteHistoryService.java
@@ -6,6 +6,7 @@ import com.addiction.user.userCigaretteHistory.document.CigaretteHistoryDocument
 import com.addiction.user.userCigaretteHistory.enums.PeriodType;
 import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryCalenderResponse;
 import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryGraphResponse;
+import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryLastestResponse;
 import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryResponse;
 
 public interface UserCigaretteHistoryService {
@@ -18,5 +19,7 @@ public interface UserCigaretteHistoryService {
 	List<UserCigaretteHistoryResponse> findHistoryByDate(String date);
 
 	UserCigaretteHistoryGraphResponse findGraphByPeriod(PeriodType periodType);
+
+    UserCigaretteHistoryLastestResponse findLastestByUserId();
 
 }

--- a/src/main/java/com/addiction/user/userCigaretteHistory/service/response/UserCigaretteHistoryLastestResponse.java
+++ b/src/main/java/com/addiction/user/userCigaretteHistory/service/response/UserCigaretteHistoryLastestResponse.java
@@ -1,0 +1,26 @@
+package com.addiction.user.userCigaretteHistory.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class UserCigaretteHistoryLastestResponse {
+
+    private final LocalDateTime lastDate;
+    private final String address;
+
+    @Builder
+    public UserCigaretteHistoryLastestResponse(LocalDateTime lastDate, String address) {
+        this.lastDate = lastDate;
+        this.address = address;
+    }
+
+    public static UserCigaretteHistoryLastestResponse createResponse(LocalDateTime lastDate, String address) {
+        return UserCigaretteHistoryLastestResponse.builder()
+            .lastDate(lastDate)
+            .address(address)
+            .build();
+    }
+}

--- a/src/test/java/com/addiction/user/userCigaretteHistory/controller/UserCigaretteHistoryControllerTest.java
+++ b/src/test/java/com/addiction/user/userCigaretteHistory/controller/UserCigaretteHistoryControllerTest.java
@@ -60,4 +60,19 @@ public class UserCigaretteHistoryControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("$.httpStatus").value("OK"))
 			.andExpect(jsonPath("$.message").value("OK"));
 	}
+
+    @DisplayName("유저의 마지막 흡연 기록을 조회한다.")
+    @Test
+    @WithMockUser(roles = "USER")
+    void 유저의_마지막_흡연_기록을_조회한다() throws Exception {
+        mockMvc.perform(
+                        get("/api/v1/user/cigarette-history/lastest")
+                                .with(csrf())
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.statusCode").value("200"))
+            .andExpect(jsonPath("$.httpStatus").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"));
+    }
 }

--- a/src/test/java/com/addiction/user/userCigaretteHistory/service/UserCigaretteHistoryServiceTest.java
+++ b/src/test/java/com/addiction/user/userCigaretteHistory/service/UserCigaretteHistoryServiceTest.java
@@ -1,0 +1,60 @@
+
+package com.addiction.user.userCigaretteHistory.service;
+
+import com.addiction.IntegrationTestSupport;
+import com.addiction.user.userCigarette.service.UserCigaretteService;
+import com.addiction.user.userCigarette.service.request.ChangeType;
+import com.addiction.user.userCigarette.service.request.UserCigaretteChangeServiceRequest;
+import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryLastestResponse;
+import com.addiction.user.users.entity.User;
+import com.addiction.user.users.entity.enums.SettingStatus;
+import com.addiction.user.users.entity.enums.SnsType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+public class UserCigaretteHistoryServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private UserCigaretteService userCigaretteService;
+    @Autowired
+    private UserCigaretteHistoryService userCigaretteHistoryService;
+
+
+	@DisplayName("유저의 마지막 흡연 기록을 조회한다.")
+	@Test
+	void 유저의_마지막_흡연_기록을_조회한다() {
+		// given
+		User user = createUser("test@test.com", "1234", SnsType.KAKAO, SettingStatus.INCOMPLETE);
+		userRepository.save(user);
+
+		given(securityService.getCurrentLoginUserInfo())
+			.willReturn(createLoginUserInfo(user.getId()));
+
+		// when
+		// then
+        UserCigaretteChangeServiceRequest request1 = UserCigaretteChangeServiceRequest.builder()
+                .changeType(ChangeType.ADD)
+                .address("서울시 강남구")
+                .build();
+        userCigaretteService.changeCigarette(request1);
+
+        UserCigaretteChangeServiceRequest request2 = UserCigaretteChangeServiceRequest.builder()
+                .changeType(ChangeType.ADD)
+                .address("서울시 송파구")
+                .build();
+        userCigaretteService.changeCigarette(request2);
+
+        // when
+        UserCigaretteHistoryLastestResponse result = userCigaretteHistoryService.findLastestByUserId();
+
+        // then
+        assertThat(result)
+                .extracting("address")
+                .isEqualTo("서울시 송파구");
+	}
+}

--- a/src/test/java/docs/users/UserCigaretteHistoryControllerDocsTest.java
+++ b/src/test/java/docs/users/UserCigaretteHistoryControllerDocsTest.java
@@ -10,9 +10,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
+import com.addiction.user.userCigaretteHistory.service.response.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -20,12 +22,6 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import com.addiction.user.userCigaretteHistory.controller.UserCigaretteHistoryController;
 import com.addiction.user.userCigaretteHistory.enums.PeriodType;
 import com.addiction.user.userCigaretteHistory.service.UserCigaretteHistoryService;
-import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryCalenderResponse;
-import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryGraphCountResponse;
-import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryGraphDateResponse;
-import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryGraphPatientResponse;
-import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryGraphResponse;
-import com.addiction.user.userCigaretteHistory.service.response.UserCigaretteHistoryResponse;
 
 import docs.RestDocsSupport;
 
@@ -176,4 +172,34 @@ public class UserCigaretteHistoryControllerDocsTest extends RestDocsSupport {
 				)
 			));
 	}
+
+    @DisplayName("userId로 최신 흡연기록 조회 API")
+    @Test
+    void findLastestByUserId() throws Exception {
+        // given
+        given(userCigaretteHistoryService.findLastestByUserId())
+                .willReturn(UserCigaretteHistoryLastestResponse.builder()
+                        .address("서울시 송파구")
+                        .lastDate(LocalDateTime.parse("2024-06-10T10:00:00"))
+                        .build());
+
+        mockMvc.perform(
+                        get("/api/v1/user/cigarette-history/lastest")
+                                .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("user-cigarette-history-lastest",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("httpStatus").type(JsonFieldType.STRING).description("HTTP 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT).description("최신 흡연 기록"),
+                                fieldWithPath("data.address").type(JsonFieldType.STRING).description("마지막 흡연 장소"),
+                                fieldWithPath("data.lastDate").type(JsonFieldType.STRING).description("마지막 흡연일시")
+                        )
+                ));
+    }
 }


### PR DESCRIPTION
## 어떤 기능인가요?

> 메인화면에 있는 마지막 흡연 기록 팝업 API 입니다.

userCIgarette 테이블을 먼저 조회 후 당일에 핀 흡연 기록이 없다면 MongoDB를 조회하도록 했습니다.